### PR TITLE
docs: typo

### DIFF
--- a/src/kiara_plugin/onboarding/modules/download/zenodo.py
+++ b/src/kiara_plugin/onboarding/modules/download/zenodo.py
@@ -106,9 +106,9 @@ class DownloadZenodoFileModule(OnboardFileModule):
 
 
 class DownloadZenodoFileBundleModule(OnboardFileBundleModule):
-    """Download a file bundle from a remote github repository.
+    """Download a file bundle from a remote zenodo record.
 
-    If 'sub_path' is not specified, the whole repo will be used.
+    If 'sub_path' is not specified, the whole record will be used.
 
     """
 


### PR DESCRIPTION
Modified words github/repo by zenodo/record in the doc for one module as per #1 